### PR TITLE
Fix Typos EN

### DIFF
--- a/de/badges.lang
+++ b/de/badges.lang
@@ -4,7 +4,7 @@
         "Badges": {
             "badgesTitle": "Orden",
             "badgesAreNotAutomaticInfo": "Orden werden nicht automatisch getrackt, auf einen Orden zu klicken 'aktiviert' diesen in der Badges Web Source",
-            "noBadgesAvilable": "Es gibt keine Orden für dieses Spiel."
+            "noBadgesAvailable": "Es gibt keine Orden für dieses Spiel."
         }
     }
 }

--- a/en-GB/badges.lang
+++ b/en-GB/badges.lang
@@ -4,7 +4,7 @@
         "Badges": {
             "badgesTitle": "Badges",
             "badgesAreNotAutomaticInfo": "Badges don't track automatically, although clicking one will 'activate' it in the Badges Web Source",
-            "noBadgesAvilable": "There are no badges available for this game."
+            "noBadgesAvailable": "There are no badges available for this game."
         }
     }
 }

--- a/en-GB/nuzlockeTools.lang
+++ b/en-GB/nuzlockeTools.lang
@@ -27,7 +27,7 @@
                 },
                 "RouteTracking": {
                     "Title": "Route Tracker",
-                    "SupportInfo": "Routes now track automatically in Gens 3, 4, 5, 6, and 7. In manual sessions, tracking utilizes the \"Location Met\" field.",
+                    "SupportInfo": "Routes now track automatically in Gens 3, 4, 5, 6, and 7. In both automatic and manual sessions, tracking utilizes the \"Location Met\" field.",
                     "OnlyPokemonInYourPartyAreTracked": "Note: The Pokémon must be in your party for it to automatically register.",
                     "YouCanManuallyTrackThemToo": "You can also manually track the routes by clicking a button below the route name.",
                     "States": {

--- a/en-GB/nuzlockeTools.lang
+++ b/en-GB/nuzlockeTools.lang
@@ -12,22 +12,22 @@
                     "ResetAllDeaths": "Reset all deaths",
                     "ResetConfirmation": {
                         "Title": "Are you sure?",
-                        "Body": "Removing all your deaths is irreversable, are you sure you wish to reset all currently tracked deaths?",
-                        "Confirm": "Yes, Reset my deaths!"
+                        "Body": "Removing all your deaths is irreversible, are you sure you wish to reset all currently tracked deaths?",
+                        "Confirm": "Yes, reset my deaths!"
                     },
                     "ResetSuccess": {
                         "Title": "Reset successful",
-                        "Body": "Your deaths have been deleted"
+                        "Body": "Your deaths have been reset"
                     }
                 },
                 "ShowdownExport": {
                     "Title": "Showdown Export",
-                    "ContentTitle": "Export your team to showdown",
-                    "ProcessDescription": "This can be used to import your team into showdown and even various online damage calculators."
+                    "ContentTitle": "Export your team to Pokémon showdown",
+                    "ProcessDescription": "This can be used to import your team into Pokémon showdown and even various online damage calculators."
                 },
                 "RouteTracking": {
                     "Title": "Route Tracker",
-                    "SupportInfo": "Routes now track automatically in Gens 3,4,5,6 &amp; 7 and also on manual sessions using the \"Location Met\" field.",
+                    "SupportInfo": "Routes now track automatically in Gens 3, 4, 5, 6, and 7. In manual sessions, tracking utilizes the \"Location Met\" field.",
                     "OnlyPokemonInYourPartyAreTracked": "Note: The Pokémon must be in your party for it to automatically register.",
                     "YouCanManuallyTrackThemToo": "You can also manually track the routes by clicking a button below the route name.",
                     "States": {

--- a/en-GB/nuzlockeTools.lang
+++ b/en-GB/nuzlockeTools.lang
@@ -7,7 +7,7 @@
                     "Title": "Death Tracker",
                     "DeathExplanation": "If a Pokémon is revived and hits 0 HP again, it will be tracked as 2 deaths. Clicking the cross will reset the death forever.",
                     "NoResults": "No deaths match your search criteria",
-                    "NoDeaths": "You've not had any deaths in this session",
+                    "NoDeaths": "You have not had any deaths in this session",
                     "TimeOfDeath": "Time of death",
                     "ResetAllDeaths": "Reset all deaths",
                     "ResetConfirmation": {

--- a/en-GB/party.lang
+++ b/en-GB/party.lang
@@ -20,7 +20,7 @@
                     "Nature": "Nature",
                     "Hidden Power": "Hidden Power",
                     "Friendship": "Friendship",
-                    "Pokerus": "Pokerus",
+                    "Pokerus": "Pokérus",
                     "Location Met": "Location Met",
                     "EVs": "EVs",
                     "IVs": "IVs",

--- a/en-GB/sessionList.lang
+++ b/en-GB/sessionList.lang
@@ -4,8 +4,8 @@
         "SessionList": {
             "sessions": "Sessions",
             "addNewSession": "Add New Session",
-            "noActiveSessions": "No Sessions found. Do you want to create one?",
-            "noArchivedSessions": "You can archive sessions for later retreival!"
+            "noActiveSessions": "No sessions found. Do you want to create one?",
+            "noArchivedSessions": "You can archive sessions for later retrieval!"
         }
     }
 }

--- a/en-GB/settings.lang
+++ b/en-GB/settings.lang
@@ -22,7 +22,7 @@
                 },
                 "RomLocation": {
                     "Title": "Rom Location",
-                    "Description": "Change the path of this file"
+                    "Description": "Change the path of your rom file"
                 },
                 "RevealEggs": {
                     "Title": "Reveal Eggs",
@@ -34,7 +34,7 @@
                 },
                 "AllowErrorReporting": {
                     "Title": "Allow Pokélink to automatically submit error reports",
-                    "Description": "Turning this off stops the app sending anonymous data when bugs happen in the app"
+                    "Description": "Turning this off stops the app from sending anonymous data when bugs happen in the app"
                 },
                 "AutomaticallyBootEmulator": {
                     "Title": "Automatically launch emulator when resuming a session",

--- a/en-GB/setup.lang
+++ b/en-GB/setup.lang
@@ -52,30 +52,30 @@
                 }
             },
             "Emulator": {
-                "Subtitle": "Now let's check the process is complete",
+                "Subtitle": "Checking if the process is complete",
                 "AttemptingToConnect": "Attempting to detect emulator... ",
-                "RunEmulatorAndOpenGame": "Please run your emulator & Open the game",
-                "CurrentlySupportedEmulators": "(Only DeSmuME, VBA, Bizhawk & Citra supported currently)",
-                "CheckForX64": "Check your emulator is \"x64\" and not \"x86\" or ask in Discord",
+                "RunEmulatorAndOpenGame": "Please run your emulator and open the game",
+                "CurrentlySupportedEmulators": "(Only DeSmuME, VBA, Bizhawk, and Citra are supported currently)",
+                "CheckForX64": "Check that your emulator is \"x64\" and not \"x86\", or ask in Discord",
                 "MultipleEmulatorsDetected": "Multiple emulators detected",
-                "NoEmulatorsFound": "No emulators found, click to try again?",
+                "NoEmulatorsFound": "No emulators found, click to try again",
                 "EmulatorFound": "Emulator Detected! (using ${emulator})",
                 "SelectADetectedEmulatorLong": "Please select one of the emulators we found running:",
                 "SelectADetectedEmulatorShort": "Select an Emulator",
                 "DoesNotSupportGeneration": "${emulator} (Doesn't support Gen ${generation})",
                 "DetectionIsPaused": "Emulator detection paused",
-                "WaitingForGameData": "Waiting for Game data...",
+                "WaitingForGameData": "Waiting for game data...",
                 "ConnectingToEmulator": "Attempting to automatically connect to ${emulator}",
                 "LoadLuaScriptIntoEmulator": "Load the Lua Script into your emulator",
                 "Instructions": {
-                    "VBA-RR": "This can be done by going to <em>Tools</em> » <em>Lua Script Window</em> » <em>New Lua Script Window</em> inside <em>VBA-ReRecording</em> <em>(Be sure not to close the script window, you can minimize it though)</em",
-                    "DeSmuME": "This can be done by going to <em>Tools</em> » <em>Lua Scripting</em> » <em>New Lua Script Window</em> inside of <em>DeSmuME</em> <em>(Be sure not to close the script window, you can minimize it though)</em>"
+                    "VBA-RR": "This can be done by going to <em>Tools</em> » <em>Lua Script Window</em> » <em>New Lua Script Window</em> inside <em>VBA-ReRecording</em> <em>(Be sure not to close the script window. You may minimize it if you wish)</em",
+                    "DeSmuME": "This can be done by going to <em>Tools</em> » <em>Lua Scripting</em> » <em>New Lua Script Window</em> inside of <em>DeSmuME</em> <em>(Be sure not to close the script window. You may minimize it if you wish)</em>"
                 },
                 "Errors": {
                     "Bizhawk": {
                         "EmulatorClosedUnexpectedly": {
                             "Title": "Bizhawk Close Detected",
-                            "Message": "Pokélink detected that Bizhawk was unexpectedly closed. If you did not intend to close Bizhawk, please end this session, close Pokélink, re-open Pokélink and resume this session to continue."
+                            "Message": "Pokélink has detected that Bizhawk was unexpectedly closed. If you did not intend to close Bizhawk, please end this session, close Pokélink, re-open Pokélink, and resume this session to continue."
                         },
                         "RomRequired": {
                             "Message": "ROM needs to be dropped in the previous step to use Bizhawk"
@@ -89,11 +89,11 @@
             "ConnectionDetails": {
                 "ConnectionTypes": {
                     "host": {
-                        "description": "You've opened up a port on your router/modem or have another way for them to connect.",
+                        "description": "You've opened up a port on your router/modem, or have another way for them to connect.",
                         "title": "Host a server"
                     },
                     "client": {
-                        "description": "Somebody else has configured their network, and I will connect to their Pokélink app.",
+                        "description": "Somebody else has configured their network and I will connect to their Pokélink app.",
                         "title": "Connect to another person"
                     }
                 }

--- a/fr-BE/badges.lang
+++ b/fr-BE/badges.lang
@@ -4,7 +4,7 @@
         "Badges": {
             "badgesTitle": "Badges",
             "badgesAreNotAutomaticInfo": "Les badges ne sont pas suivis automatiquement, même si vous clickez un pour 'activater' dans la source web de badges.",
-            "noBadgesAvilable": "Il n'y a pas des badges disponible pour cette jeu."
+            "noBadgesAvailable": "Il n'y a pas des badges disponible pour cette jeu."
         }
     }
 }

--- a/it/badges.lang
+++ b/it/badges.lang
@@ -4,7 +4,7 @@
         "Badges": {
             "badgesTitle": "Medaglie",
             "badgesAreNotAutomaticInfo": "Le medaglie non sono tracciate automaticamente, tuttavia cliccandone una questa sarà 'attivata' nella Web Source Medaglie",
-            "noBadgesAvilable": "Non è disponibile nessuna medaglia per questo gioco."
+            "noBadgesAvailable": "Non è disponibile nessuna medaglia per questo gioco."
         }
     }
 }

--- a/nl-BE/badges.lang
+++ b/nl-BE/badges.lang
@@ -4,7 +4,7 @@
         "Badges": {
             "badgesTitle": "Badges",
             "badgesAreNotAutomaticInfo": "Badges worden niet automatisch getraceert alhoewel, erop klikken, het 'activeerd' in de webbron",
-            "noBadgesAvilable": "Er zijn geen badges beschikbaar voor dit spel."
+            "noBadgesAvailable": "Er zijn geen badges beschikbaar voor dit spel."
         }
     }
 }

--- a/no/badges.lang
+++ b/no/badges.lang
@@ -4,7 +4,7 @@
         "Badges": {
             "badgesTitle": "Knappenåler",
             "badgesAreNotAutomaticInfo": "Knappenåler blir ikke avlest automatisk, men å klikke en vil 'aktivere' den i Knappenål Nett Kilden!",
-            "noBadgesAvilable": "Det er ingen knappenåler tilgjengelige for dette spillet."
+            "noBadgesAvailable": "Det er ingen knappenåler tilgjengelige for dette spillet."
         }
     }
 }


### PR DESCRIPTION
- Change key name "noBadgesAvilable" -> "noBadgesAvailable" in all badges.lang files
- Nitpicky grammar changes in `nuzlockeTools.lang`
    - Change "You've" to "You have" in `noDeaths`
    - Fix misspelling of "irreversible" and normalize capitalization in `ResetConfirmation`
    - Update language to be more consistent in `ResetSuccess` body
    - Change "showdown" to "Pokémon showdown" in `ShowdownExport` for clarity
    - Change "Routes now track automatically in Gens 3,4,5,6 &amp; 7 and also on manual sessions using the \"Location Met\" field." to more grammatically nice "Routes now track automatically in Gens 3, 4, 5, 6, and 7. In both automatic and manual sessions, tracking utilizes the \"Location Met\" field." (better spacing for gens, add oxford comma, split up run-on sentence)
- Replace 'e' with 'é' for Pokérus in `party.lang` for consistency 
- Normalize capitalization + fix typo ("retreival" -> "retrieval") in `sessionList.lang`
- Minor grammar update + clarity improvement for rom file in `settings.lang`
- A bunch of little grammar updates in `setup.lang`