### PR TITLE
Added german translations for azahar portable mode

### DIFF
--- a/de/0.7.0/emulator.lang
+++ b/de/0.7.0/emulator.lang
@@ -64,8 +64,8 @@
         "linuxInstructions": " kopiere die ${extension} Datei in Pokélink's Emulator-Ordner und ziehe die kopierte Datei per Drag-and-Drop in Pokélink.",
         "ConfigItems": {
           "PortableMode": {
-            "name": "Enable Portable Mode",
-            "description": "Allows Azahar to not use your global instance. Useful for randomized runs"
+            "name": "Portable Mode aktivieren",
+            "description": "Zwingt Azahar im Portable Mode zu starten. Nützlich für randomized Runs."
           }
         }
       },

--- a/de/0.7.0/features.lang
+++ b/de/0.7.0/features.lang
@@ -3,8 +3,6 @@
   "translations": {
     "Features": {
       "Pokelink": {
-        "supported": "Unterstützte Features",
-        "unsupported": "Nicht unterstützte Features",
         "KnownIssues": {
           "doNotSaveInLumiose": "Speichere das Spiel nicht in Illumina City, aufgrund eines Bugs kann dies dein Savegame beschädigen. Update auf 1.5 wenn du kannst",
           "Gen2": {


### PR DESCRIPTION
As the title says. Added german translation for emulator.Azahar.PortableMode.

It's not a direct translation of "allows azahar to not use your global instance". if i got it right this option enforces azahar to use its portable mode, so i translated it from "(en)forces azahar to start in portable mode. useful for randomized runs".

i also stumbled upon and fixed a mistake from my earlier PR where i accidentally (perhaps during resolving a merge-conflict) added nonexistent keys to features.Pokelink instead of features 😅 